### PR TITLE
[Rust kit] Fix `can_build` condition

### DIFF
--- a/kits/rust/simple/lux/src/entities/units.rs
+++ b/kits/rust/simple/lux/src/entities/units.rs
@@ -249,7 +249,7 @@ impl Unit {
 
     /// Check if Unit can build [`CityTile`], i.e. cooldown is less than 1 and
     /// unit is worker and cell not has resource and amount of resources is
-    /// greater than needed
+    /// greater or equal than needed
     ///
     /// # Parameters
     ///


### PR DESCRIPTION
Hi!
Implemented fix for Rust Kit bug #160. Condition should contain `=`, this PR fixes it.